### PR TITLE
$basePath is not required.

### DIFF
--- a/app/templates/Default/@layout-empty.latte
+++ b/app/templates/Default/@layout-empty.latte
@@ -39,11 +39,11 @@
 	{block #content}{/block}
 	<div id="footer">
 		<div id="logos">
-			<a href="http://ksi.fi.muni.cz" target="_blank"><img id="ksi" src="{$basePath}/img/ksi.svg"></a>
-			<a href="http://ibis.sci.muni.cz/" target="_blank"><img id="ibis" src="{$basePath}/img/ibis.svg"></a>
-			<a href="http://fi.muni.cz" target="_blank"><img id="fi" src="{$basePath}/img/fi.svg"></a>
-			<a href="http://www.sci.muni.cz/" target="_blank"><img id="prf" src="{$basePath}/img/prf.svg"></a>
-			<a href="http://www.muni.cz" target="_blank"><img id="muni" src="{$basePath}/img/mu.svg"></a>
+			<a href="http://ksi.fi.muni.cz" target="_blank"><img id="ksi" src="/img/ksi.svg"></a>
+			<a href="http://ibis.sci.muni.cz/" target="_blank"><img id="ibis" src="/img/ibis.svg"></a>
+			<a href="http://fi.muni.cz" target="_blank"><img id="fi" src="/img/fi.svg"></a>
+			<a href="http://www.sci.muni.cz/" target="_blank"><img id="prf" src="/img/prf.svg"></a>
+			<a href="http://www.muni.cz" target="_blank"><img id="muni" src="/img/mu.svg"></a>
 		</div>
 		<div id="email">
 			kscuk@fi.muni.cz


### PR DESCRIPTION
Myslím si, že v kódu by nemělo být použité `$basePath` pokud to není třeba. Svou argumentaci stavím na předpokladu, že `$basePath` se chová stejně jako kdybych před relativní adresu přidal `/`. Pokud je tento přepoklad špatný, prosím, řekněte mi to.

Proč si myslím, že by se `$basePath` nemělo použivat? Protože se jedná o vnitřní proměnnou Nette. Je vysoce pravděpodobné, že se změní ikonka nějaké akce a bude požadavek ji změnit v zápatí. Tuto změnu bude možná dělat někdo, do Nette v životě neviděl. Proč by takový člověk měl přemýšlet nad tím, jestli v kódu musí být zachován `$basePath` místo toho, aby viděl běžné `/img/abc.svg`, které chápe, protože znalost relativních a absolutní cest je elementární informatická znalost.

Zásadně neosuhlasím s tím, aby se pro standardní věci používaly speciální konstrukce jazyka místo standardních řešení. `/` je standardní řešení napříč celým webem, `$basePath` je záležitost Nette. Pokud nemají nestandardní řešení speciální funkcionalitu, jen zbytečně snižují čitelnost a pochopitelnost kódu.